### PR TITLE
Replace notion of "deployed" with "active"

### DIFF
--- a/bin/delete_without_backup
+++ b/bin/delete_without_backup
@@ -3,19 +3,19 @@
 import sys
 from deployer.models import Droplet
 
-droplet = Droplet.query.filter_by(name=sys.argv[1]).first()
-test_droplet = Droplet.query.filter_by(name=sys.argv[1]+"-test").first()
+droplet = Droplet.query.filter_by(name=sys.argv[1], active=True).first()
+test_droplet = Droplet.query.filter_by(name=sys.argv[1]+"-test", active=True).first()
 
 if droplet:
-    print("Destroying main droplet...")
-    droplet.destroy()
+    print("Deactivating main droplet...")
+    droplet.deactivate()
     print("Success!")
 else:
     print("No droplet found")
 
 if test_droplet:
-    print("Destroying test droplet...")
-    test_droplet.destroy()
+    print("Deactivating test droplet...")
+    test_droplet.deactivate()
     print("Success!")
 else:
     print("No test droplet found")

--- a/deployer/forms.py
+++ b/deployer/forms.py
@@ -19,8 +19,8 @@ def validate_name(form, field):
 
 
 def validate_unique_name(form, field):
-    if Droplet.query.filter_by(name=field.data.lower()).count() > 0:
-        raise ValidationError('A tournament with that name already exists')
+    if Droplet.query.filter_by(name=field.data.lower(), active=True).count() > 0:
+        raise ValidationError('An active tournament with that name already exists')
 
 #################
 # Form definition

--- a/deployer/models.py
+++ b/deployer/models.py
@@ -13,7 +13,7 @@ class Droplet(db.Model):
     name = db.Column(db.String, nullable=False)
     droplet_name = db.Column(db.String, nullable=True)
     status = db.Column(db.String, nullable=True)
-    deployed = db.Column(db.Boolean, default=False)
+    active = db.Column(db.Boolean, default=True)
     created_at = db.Column(db.DateTime, nullable=False)
     clone_url = db.Column(db.String, nullable=True)
     branch = db.Column(db.String, nullable=True)
@@ -63,17 +63,12 @@ class Droplet(db.Model):
         db.session.add(self)
         return db.session.commit()
 
-    def set_deployed(self):
-        self.deployed = True
-        self.status = 'Deployed'
-        db.session.add(self)
-        return db.session.commit()
-
-    def destroy(self):
+    def deactivate(self):
         self.domain_record and self.domain_record.destroy()
         self.droplet and self.droplet.destroy()
+        self.active = False
 
-        db.session.delete(self)
+        db.session.add(self)
         return db.session.commit()
 
     def __repr__(self):

--- a/deployer/tasks.py
+++ b/deployer/tasks.py
@@ -95,9 +95,10 @@ def deploy_droplet(droplet, password, size):
 
         droplet.set_status('Creating domain name')
         droplet.create_domain()
-        droplet.set_deployed()
+        droplet.set_status('Deployed')
     except Exception as e:
         droplet.set_status('An error occurred')
+        droplet.deactivate()
         raise e
 
 

--- a/deployer/templates/show.html
+++ b/deployer/templates/show.html
@@ -4,7 +4,7 @@
 <div id="tournament">
   <center>
     <h2>[[ tournament.name ]]</h3>
-    <div v-if="tournament.deployed">
+    <div v-if="deployed">
       <span class="lead">Deployed!</span>
       <br/>
       <small>
@@ -31,22 +31,26 @@ var app = new Vue({
   data: {
     tournament: {
       name: '{{ tournament.name }}',
-      status: '{{ tournament.status }}',
-      deployed: '{{ tournament.deployed }}' == 'True'
+      status: '{{ tournament.status }}'
     },
     dots: 3
   },
   // Use [[  ]] to wrap vue to prevent conflicts with Jinja
   delimiters: ['[[',']]'],
+  computed: {
+    deployed: function() {
+      return this.tournament.status == 'Deployed'
+    }
+  },
   methods: {
     updateTournament: function() {
       axios.get(window.location + '/status')
         .then(function(response) {
           data = response.data
           this.tournament.status = data.status
-          this.tournament.deployed = data.deployed
+          this.deployed = data.deployed
 
-          if (this.tournament.deployed) {
+          if (this.deployed) {
             clearInterval(this.intervals.tournament)
             clearInterval(this.intervals.dots)
           }


### PR DESCRIPTION
An `active` tournament is a tournament that is either being set up or is currently set up. Rather than deleting the database entries of tournaments, we should simply set them to inactive

This will drastically improve the process of creating a tournament and then having the tournament creation fail. It is also a more accurate data model that will allow things like storing the s3 links of tab cards, db backups, etc.