### PR TITLE
Fix Staticfile Serving Problem

### DIFF
--- a/deployer/clients/digital_ocean.py
+++ b/deployer/clients/digital_ocean.py
@@ -69,12 +69,20 @@ def __build_app_spec(name, tab_password, database, repo_slug, branch):
             "routes": [{ "path": "/" }],
         }],
         "static_sites": [{
-            "name": "static",
-            "output_dir": "/var/www/tab/assets",
+            "name": "django-static",
+            "output_dir": "/var/www/tab/staticfiles",
             "dockerfile_path": "Dockerfile.static",
             "github": github_config,
             "routes": [{ "path": "/static" }]
-        }],
+        },
+        {
+            "name": "webpack-static",
+            "output_dir": "/var/www/tab/assets/webpack_bundles",
+            "dockerfile_path": "Dockerfile.static",
+            "github": github_config,
+            "routes": [{ "path": "/static/webpack_bundles" }]
+        }
+        ],
         "envs": [
             env_var("TAB_PASSWORD", tab_password, True),
             env_var("MYSQL_DATABASE", "${%s.DATABASE}" % database["name"]),


### PR DESCRIPTION
TLDR:
- mittab saves webpack bundles in /var/www/tab/assets, all other static resources (admin styling included) in /var/www/tab/staticfiles
- The frontend is expecting all statics (both webpack and otherwise) at /static
- The current DO static sites config serves all /static/ requests from assets, hence the 404 for non webpack static files

Obviously a few ways we can resolve this, but I landed on this one because I belive it's the only one that only requires changes to one branch, and generally messes with as few configurations as possible. Tested and serving both webpack and admin styling without a problem on my personal DO.